### PR TITLE
Split concrete Contract class into an interface and RatifiedContract

### DIFF
--- a/src/api/AtomicBoolean.ts
+++ b/src/api/AtomicBoolean.ts
@@ -1,5 +1,6 @@
 import { OptionalType, hasFunctions } from "./Types";
 import { Contract, Config as ContractConfig } from "./Contract";
+import { create as createContract } from "./RatifiedContract";
 import { Lawyer } from "./Lawyer";
 
 /**
@@ -55,7 +56,7 @@ export const LAWYER: Lawyer<AtomicBoolean> = new class implements Lawyer<AtomicB
         copy.test ??= this.isDeliverable;
         copy.typeName ??= "AtomicBoolean";
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 };
 

--- a/src/api/AtomicBooleanFactory.ts
+++ b/src/api/AtomicBooleanFactory.ts
@@ -2,6 +2,8 @@ import { AtomicBoolean } from "./AtomicBoolean";
 import { RequiredType, OptionalType, hasFunctions } from "./Types";
 import { Contract, Config as ContractConfig } from "./Contract";
 import { Lawyer } from "./Lawyer";
+import { create as createContract } from "./RatifiedContract";
+
 
 /**
  * Factory interface for creating AtomicBoolean instances.
@@ -36,7 +38,7 @@ export const LAWYER: Lawyer<AtomicBooleanFactory> = new class implements Lawyer<
         copy.test ??= this.isDeliverable;
         copy.typeName ??= "AtomicBooleanFactory";
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 };
 

--- a/src/api/AtomicInteger.ts
+++ b/src/api/AtomicInteger.ts
@@ -1,6 +1,7 @@
 import { OptionalType, hasFunctions } from "./Types";
 import { Contract, Config as ContractConfig } from "./Contract";
 import { Lawyer } from "./Lawyer";
+import { create as createContract } from "./RatifiedContract";
 
 /**
  * Responsibility: An atomic integer interface for thread-safe integer operations.
@@ -40,7 +41,7 @@ export const LAWYER: Lawyer<AtomicInteger> = new class implements Lawyer<AtomicI
         copy.test ??= this.isDeliverable;
         copy.typeName ??= "AtomicInteger";
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 };
 

--- a/src/api/AtomicIntegerFactory.ts
+++ b/src/api/AtomicIntegerFactory.ts
@@ -2,6 +2,7 @@ import { OptionalType, RequiredType, hasFunctions } from "./Types";
 import { Contract, Config as ContractConfig } from "./Contract";
 import { Lawyer } from "./Lawyer";
 import { AtomicInteger } from "./AtomicInteger";
+import { create as createContract } from "./RatifiedContract";
 
 /**
  * Factory interface for creating AtomicInteger instances.
@@ -36,7 +37,7 @@ export const LAWYER: Lawyer<AtomicIntegerFactory> = new class implements Lawyer<
         copy.test ??= this.isDeliverable;
         copy.typeName ??= "AtomicIntegerFactory";
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 };
 

--- a/src/api/AtomicReference.ts
+++ b/src/api/AtomicReference.ts
@@ -1,6 +1,7 @@
 import { OptionalType, hasFunctions } from "./Types";
 import { Contract, Config as ContractConfig } from "./Contract";
 import { Lawyer } from "./Lawyer";
+import { create as createContract } from "./RatifiedContract";
 
 /**
  * Responsibility: An atomic reference interface for thread-safe reference operations.
@@ -36,6 +37,6 @@ export const LAWYER: Lawyer<AtomicReference<unknown>> = new class implements Law
         copy.test ??= this.isDeliverable;
         copy.typeName ??= "AtomicReference";
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 }

--- a/src/api/AtomicReferenceFactory.ts
+++ b/src/api/AtomicReferenceFactory.ts
@@ -2,6 +2,7 @@ import { OptionalType, RequiredType, hasFunctions } from "./Types";
 import { Contract, Config as ContractConfig } from "./Contract";
 import { Lawyer } from "./Lawyer";
 import { AtomicReference } from "./AtomicReference";
+import { create as createContract } from "./RatifiedContract";
 
 /**
  * Factory interface for creating AtomicReference instances.
@@ -36,7 +37,7 @@ export const LAWYER: Lawyer<AtomicReferenceFactory> = new class implements Lawye
         copy.test ??= this.isDeliverable;
         copy.typeName ??= "AtomicReferenceFactory";
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 }
 

--- a/src/api/Contract.ts
+++ b/src/api/Contract.ts
@@ -1,6 +1,4 @@
-import { isNullOrUndefined, OptionalType } from "./Types";
-import { ClassCastException } from "./ClassCastException";
-import { ContractException } from "./ContractException";
+import { OptionalType } from "./Types";
 
 /**
  * Configuration for a Contract
@@ -55,18 +53,7 @@ export interface Config<T> {
  * Note: This is a final class and should not be extended!
  * @param <T> the type of deliverable for this Contract
  */
-export class Contract<T> {
-
-    /**
-      * Create a contract derived from the given configuration
-      *
-      * @param config the name for the contract, null is not allowed
-      * @param <T>    the type of deliverable for this Contract
-      * @return the new Contract
-      */
-    public static create<T>(config?: Config<T> | null): Contract<T> {
-        return new Contract<T>(config);
-    }
+export interface Contract<T> {
 
     /**
     * Casts the given object to the return type for this Contract
@@ -76,20 +63,12 @@ export class Contract<T> {
     * @return the checked value. Note: null is possible. The Promisor is allowed to return null
     * @throws ClassCastException iif the value can't be cast to the return type.
     */
-    public cast(value: unknown | null | undefined): OptionalType<T> {
-        if (this.tester(value)) {
-            return this.caster(value) as OptionalType<T>;
-        } else {
-            throw new ClassCastException(`${this.toString()} cast failed.`);
-        }
-    }
+    cast(value: OptionalType<unknown>): OptionalType<T>;
 
     /**
      * @return the contract name
      */
-    public getName(): string {
-        return this.name;
-    }
+    getName(): string;
 
     /**
      * Note: Do not rely on this being a java class name
@@ -97,9 +76,7 @@ export class Contract<T> {
      *
      * @return the type of deliverable for this contract.
      */
-    public getTypeName(): string {
-        return this.typeName;
-    }
+    getTypeName(): string;
 
     /**
      * When replaceable a new binding can replace in an existing one
@@ -107,75 +84,7 @@ export class Contract<T> {
      *
      * @return true if replaceable
      */
-    public isReplaceable(): boolean {
-        return this.replaceable;
-    }
-
-    /**
-     * String representation of this Contract
-     * Note: not intended to be parsed or relied on.
-     * @returns a string representation of the contract
-     */
-    public toString(): string {
-        return `Contract(id=${this.id}, name=${this.name}, type=${this.typeName})`;
-    }
-
-    /**
-     * Duck-typing check for Contract interface.
-     * 
-     * @param instance the instance to check
-     * @returns true if the instance is a Contract, false otherwise
-     */
-    static isContract<T>(instance: any): instance is Contract<T> {
-        if (isNullOrUndefined(instance)) {
-            return true;
-        }
-        if (instance instanceof Contract) {
-            instance.integrityCheck();
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * This is a security check to prevent duck-typing or extending Contract class.
-     * 
-     * Note: When invoked by the constructor it is early in the initialization phase so
-     * most fields are not yet initialized.
-     */
-    private integrityCheck(): void {
-        try {
-            // Accessing private field to ensure it's really a Contract
-             
-            if (this.#secret !== Contract.#SECRET) {
-                throw new Error("Identifier  mismatch.");
-            }
-        } catch (thrown) {
-            throw new ContractException('Security violation detected. This is not permitted.');
-        }
-    }
-
-    private constructor(config?: Config<T> | null) {
-        this.integrityCheck()
-        const candidateConfig: Config<T> = config ?? {};
-        this.replaceable = candidateConfig?.isReplaceable ?? false;
-        this.name = candidateConfig?.name ?? "";
-        this.typeName = candidateConfig?.typeName ?? "";
-        this.tester = candidateConfig?.test ?? ((instance: unknown): instance is OptionalType<T> => true);
-        this.caster = candidateConfig?.cast ?? ((instance: unknown) => instance);
-        Object.freeze(this);
-    }
-
-    private static ID_GENERATOR: number = 1;
-    static readonly #SECRET : symbol = Symbol("Contract");
-
-    readonly #secret : symbol = Contract.#SECRET;
-    private readonly id: number = Contract.ID_GENERATOR++;
-    private readonly name: string;
-    private readonly typeName: string;
-    private readonly tester: (instance: unknown) => instance is OptionalType<T>;
-    private readonly caster: (instance: unknown) => unknown;
-    private readonly replaceable: boolean;
+    isReplaceable(): boolean;
 }
 
 

--- a/src/api/Promisor.ts
+++ b/src/api/Promisor.ts
@@ -2,6 +2,7 @@ import { OptionalType, RequiredType, isRequiredConstructor, hasFunctions } from 
 import { nullCheck } from "./Checks";
 import { Contract, Config as ContractConfig } from "./Contract";
 import { Lawyer } from "./Lawyer";
+import { create as createContract } from "./RatifiedContract";
 
 /**
  * Interface for providing a deliverable for a Contract
@@ -57,7 +58,7 @@ export const LAWYER: Lawyer<Promisor<unknown>> = new class implements Lawyer<Pro
         copy.test ??= this.isDeliverable;
         copy.typeName ??= "Promisor";
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 }
 

--- a/src/api/PromisorFactory.ts
+++ b/src/api/PromisorFactory.ts
@@ -2,6 +2,7 @@ import { OptionalType, RequiredType, Transform, hasFunctions } from "./Types";
 import { Contract, Config as ContractConfig } from "./Contract";
 import { Promisor, PromisorType } from "./Promisor";
 import { Lawyer } from "./Lawyer";
+import { create as createContract } from "./RatifiedContract";
 
 /**
  * Helper methods for creating and chaining Promisors used for {@link Contractss#bind(Contract, Promisor)}
@@ -72,7 +73,7 @@ export const LAWYER: Lawyer<PromisorFactory> = new class implements Lawyer<Promi
         copy.test ??= this.isDeliverable;
         copy.typeName ??= "PromisorFactory";
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 };
 

--- a/src/api/RatifiedContract.ts
+++ b/src/api/RatifiedContract.ts
@@ -1,0 +1,131 @@
+import { OptionalType, isNullOrUndefined} from "./Types";
+import { ClassCastException } from "./ClassCastException";
+import { ContractException } from "./ContractException";
+import { Contract, Config } from "./Contract";
+
+export function create<T>(config?: Config<T> | null) : Contract<T> {
+    return RatifiedContract.create<T>(config);
+}
+
+export function isRatifiedContract(instance: unknown): instance is RatifiedContract<unknown> {
+    return RatifiedContract.isRatifiedContract(instance);
+}
+
+class RatifiedContract<T> implements Contract<T> {
+
+    /**
+      * Create a contract derived from the given configuration
+      *
+      * @param config the name for the contract, null is not allowed
+      * @param <T>    the type of deliverable for this Contract
+      * @return the new Contract
+      */
+    static create<T>(config?: Config<T> | null): Contract<T> {
+        return new RatifiedContract<T>(config);
+    }
+
+    static isRatifiedContract(instance: unknown): instance is RatifiedContract<unknown> {
+        if (isNullOrUndefined(instance)) {
+            return false;
+        }
+
+        try {
+            const candidate = instance as RatifiedContract<unknown>;
+            return candidate.#secret === RatifiedContract.#SECRET;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+    * Casts the given object to the return type for this Contract
+    * This is used to make sure the value is a checked value and does not sneak passed during erasure
+    *
+    * @param value the value to cast
+    * @return the checked value. Note: null is possible. The Promisor is allowed to return null
+    * @throws ClassCastException iif the value can't be cast to the return type.
+    */
+    public cast(value: unknown | null | undefined): OptionalType<T> {
+        if (this.tester(value)) {
+            return this.caster(value) as OptionalType<T>;
+        } else {
+            throw new ClassCastException(`${this.toString()} cast failed.`);
+        }
+    }
+
+    /**
+     * @return the contract name
+     */
+    public getName(): string {
+        return this.name;
+    }
+
+    /**
+     * Note: Do not rely on this being a java class name
+     * Note: The actual class is never exposed and is by design.
+     *
+     * @return the type of deliverable for this contract.
+     */
+    public getTypeName(): string {
+        return this.typeName;
+    }
+
+    /**
+     * When replaceable a new binding can replace in an existing one
+     * The default is false
+     *
+     * @return true if replaceable
+     */
+    public isReplaceable(): boolean {
+        return this.replaceable;
+    }
+
+    /**
+     * String representation of this Contract
+     * Note: not intended to be parsed or relied on.
+     * @returns a string representation of the contract
+     */
+    public toString(): string {
+        return `Contract(id=${this.id}, name=${this.name}, type=${this.typeName})`;
+    }
+
+    /**
+     * This is a security check to prevent duck-typing or extending Contract class.
+     * 
+     * Note: When invoked by the constructor it is early in the initialization phase so
+     * most fields are not yet initialized.
+     */
+    private integrityCheck(): void {
+        try {
+            // Accessing private field to ensure it's really a Contract
+             
+            if (this.#secret !== RatifiedContract.#SECRET) {
+                throw new Error("Identifier  mismatch.");
+            }
+        } catch (thrown) {
+            throw new ContractException('Security violation detected. This is not permitted.');
+        }
+    }
+
+    private constructor(config?: Config<T> | null) {
+        this.integrityCheck()
+        const candidateConfig: Config<T> = config ?? {};
+        this.replaceable = candidateConfig?.isReplaceable ?? false;
+        this.name = candidateConfig?.name ?? "";
+        this.typeName = candidateConfig?.typeName ?? "";
+        this.tester = candidateConfig?.test ?? ((instance: unknown): instance is OptionalType<T> => true);
+        this.caster = candidateConfig?.cast ?? ((instance: unknown) => instance);
+        Object.freeze(this);
+    }
+
+    private static ID_GENERATOR: number = 1;
+    static readonly #SECRET : symbol = Symbol("Contract");
+
+    readonly #secret : symbol = RatifiedContract.#SECRET;
+    private readonly id: number = RatifiedContract.ID_GENERATOR++;
+    private readonly name: string;
+    private readonly typeName: string;
+    private readonly tester: (instance: unknown) => instance is OptionalType<T>;
+    private readonly caster: (instance: unknown) => unknown;
+    private readonly replaceable: boolean;
+}

--- a/src/api/Repository.ts
+++ b/src/api/Repository.ts
@@ -5,6 +5,7 @@ import { PromisorType } from "./Promisor";
 import { BindStrategy } from "./BindStrategy";
 import { AutoClose } from "./AutoClose";
 import { Lawyer } from "./Lawyer";
+import { create as createContract } from "./RatifiedContract";
 
 /**
  * A repository for multiple contract promisors
@@ -76,6 +77,6 @@ export const LAWYER: Lawyer<Repository> = new class implements Lawyer<Repository
         copy.typeName ??= "Repository";
         copy.test ??= this.isDeliverable;
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 };

--- a/src/api/RepositoryFactory.ts
+++ b/src/api/RepositoryFactory.ts
@@ -1,6 +1,7 @@
 import { OptionalType, RequiredType, hasFunctions } from "./Types";
 import { Repository } from "./Repository";
 import { Contract, Config as ContractConfig } from "./Contract";
+import { create as createContract } from "./RatifiedContract";
 import { Lawyer } from "./Lawyer";
 
 /**
@@ -35,7 +36,7 @@ export const LAWYER: Lawyer<RepositoryFactory> = new class implements Lawyer<Rep
         copy.test ??= this.isDeliverable;
         copy.typeName ??= "RepositoryFactory";
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 };
 

--- a/src/api/Validate.ts
+++ b/src/api/Validate.ts
@@ -3,6 +3,7 @@ import { AutoClose } from "./AutoClose";
 import { Contract } from "./Contract";
 import { ContractException } from "./ContractException";
 import { Contracts } from "./Contracts";
+import { create as createContract } from "./RatifiedContract";
 
 /**
 * A simple runtime validation of deployed implementation
@@ -12,7 +13,7 @@ import { Contracts } from "./Contracts";
 export function validateContracts(contracts: Contracts): void {
     const validContracts: Contracts = contractsCheck(contracts);
     try {
-        const contract: Contract<Date> = Contract.create<Date>({ });
+        const contract: Contract<Date> = createContract<Date>({ });
         const deliverableValue: Date = new Date();
 
         if (validContracts.isBound(contract)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,12 @@
 import { RequiredType } from "./api/Types";
 import { Contracts, Config as ContractsConfig } from "./api/Contracts";
-import { Contract, Config as ContractConfig } from "./api/Contract";
-import { create as createContractsFactory } from "./impl/ContractsFactoryImpl";       
+import { create as createContractsFactory } from "./impl/ContractsFactoryImpl";  
 
 export function createContracts(config?: ContractsConfig): RequiredType<Contracts> {
     return createContractsFactory().create(config);
 }   
 
-export function createContract<T>(config?: ContractConfig<T>): RequiredType<Contract<T>> {
-    return Contract.create<T>(config);
-}   
-
+export { create as createContract } from "./api/RatifiedContract"; 
 export { create as createContractsFactory } from "./impl/ContractsFactoryImpl";
 
 

--- a/src/test/Contract.test.ts
+++ b/src/test/Contract.test.ts
@@ -6,9 +6,10 @@ import { Tools } from "./Test.tools.test";
 import { generateContractSuite } from "./Contract.tools.test";
 import { isString } from "../api/Types";
 import { ClassCastException } from "../api/ClassCastException";
+import { createContract } from "../index";
 
 describe('Create string contract', () => {
-  const contract: Contract<string> = Contract.create<string>({
+  const contract: Contract<string> = createContract<string>({
     name: "Test String Contract",
     test: isString,
     typeName: "string",
@@ -39,19 +40,8 @@ describe('Create string contract', () => {
   });
 });
 
-describe('Prohibit duck typing or extending Contract class', () => {
-  assert.throws(() => {
-    const instance: Contract<string> = new (Contract<string> as any)["constructor"]();
-    Object.setPrototypeOf(instance, Contract.prototype);
-    Contract.isContract(instance);
-  }, {
-    name: 'ContractException',
-    message: "Security violation detected. This is not permitted."
-  });
-});
-
 test('contract_Config_Defaults', () => {
-  const defaults: Contract<string> = Contract.create<string>({ test: isString });
+  const defaults: Contract<string> = createContract<string>({ test: isString });
   Tools.assertAll(
     () => Tools.assertFalse(defaults.isReplaceable(), "Default for replaceable."),
     () => Tools.assertEquals("", defaults.getName(), "Default for name."),
@@ -62,7 +52,7 @@ test('contract_Config_Defaults', () => {
 });
 
 test('contract_create_withNullConfig_Works', () => {
-  const contract: Contract<string> = Contract.create<string>(null);
+  const contract: Contract<string> = createContract<string>(null);
 
   assert.ok(contract);
 });

--- a/src/test/Contract.tools.test.ts
+++ b/src/test/Contract.tools.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert';
 
 import { Contract } from "../api/Contract";
+import { createContract } from "../index"
 
 export interface CastCase<T> {
-    instance: any;
+    instance: unknown;
     expected?: T;
     help?: string;
 }
@@ -15,7 +16,7 @@ export interface ContractSuiteOptions<T> {
     invalidCases?: CastCase<T>[];
 }
 
-const someContract: Contract<string> = Contract.create<string>();
+const someContract: Contract<string> = createContract<string>();
 
 generateContractSuite({
     name: 'SomeContract',
@@ -31,7 +32,7 @@ export function generateContractSuite<T>(options: ContractSuiteOptions<T>) {
     describe(`Contract Suite for ${options.name}`, () => {
         validCases?.forEach((testCase, index) => {
             const help = testCase?.help ?? String(testCase.instance);
-            const expected: T = testCase.expected ?? testCase.instance;
+            const expected = testCase?.expected ?? testCase.instance;
             const scenario: string = `case ${index} => (${help}) : return ${expected}`;
 
             it(scenario, () => {

--- a/src/test/ExtractorPromisor.test.ts
+++ b/src/test/ExtractorPromisor.test.ts
@@ -6,6 +6,7 @@ import { Contracts } from "../api/Contracts";
 import { Contract } from "../api/Contract";
 import { Promisor, typeToPromisor  } from "../api/Promisor";
 import { PromisorFactory, CONTRACT as PROMISORS_CONTRACT } from "../api/PromisorFactory";
+import { createContract } from "../index";
 
 describe('Extract Promisor tests', () => {
 
@@ -26,7 +27,7 @@ describe('Extract Promisor tests', () => {
 
         Tools.withContracts((contracts: Contracts) => {
             const promisorFactory: PromisorFactory = contracts.enforce(PROMISORS_CONTRACT);
-            const contract: Contract<string> = Contract.create<string>();
+            const contract: Contract<string> = createContract<string>();
             const promisor: Promisor<string> = promisorFactory.createExtractor<Date, string>(referent, transform);
 
             using usingPromisor = contracts.bind(contract, promisor);

--- a/src/test/Lawyer.tools.test.ts
+++ b/src/test/Lawyer.tools.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert';
 import { OptionalType, RequiredType } from "../api/Types";
 import { Config as ContractConfig, Contract } from "../api/Contract";
 import { Lawyer } from "../api/Lawyer";
+import { createContract } from "../index";
 
 const LAWYER : Lawyer<Date> = new class implements Lawyer<Date> {
     createContract<X extends Date>(config?: ContractConfig<X> | undefined): RequiredType<Contract<X>>{
@@ -10,7 +11,7 @@ const LAWYER : Lawyer<Date> = new class implements Lawyer<Date> {
 
         copy.test ??= (instance: unknown): instance is X => instance === null || instance === undefined || instance instanceof Date;
 
-        return Contract.create<X>(copy);
+        return createContract<X>(copy);
     }
 
     isDeliverable<X extends Date>(instance: unknown): instance is OptionalType<X> {

--- a/src/test/LifeCyclePromisor.test.ts
+++ b/src/test/LifeCyclePromisor.test.ts
@@ -7,13 +7,14 @@ import { PromisorFactory, CONTRACT as PROMISORS_CONTRACT } from "../api/Promisor
 import { AtomicInteger } from "../api/AtomicInteger";
 import { CONTRACT as ATOMIC_INTEGER_FACTORY } from "../api/AtomicIntegerFactory";
 import { ClassCastException } from "../api/ClassCastException";
+import { createContract } from "../index";
 
 describe('LifeCyclePromisor tests', () => {
     it('Reentrancy failure: Issue #69', () => {
         Tools.withContracts((contracts: Contracts) => {
             const promisorFactory: PromisorFactory = contracts.enforce(PROMISORS_CONTRACT);
             const openCounter: AtomicInteger = contracts.enforce(ATOMIC_INTEGER_FACTORY).create();
-            const contract: Contract<AutoOpen> = Contract.create<AutoOpen>({
+            const contract: Contract<AutoOpen> = createContract<AutoOpen>({
                 name: "ReentrancyPromisor",
                 typeName: "AutoOpen",
                 cast: (obj: unknown): AutoOpen => {

--- a/src/test/Repository.test.ts
+++ b/src/test/Repository.test.ts
@@ -7,6 +7,7 @@ import { ContractException } from "../api/ContractException";
 import { Contracts } from "../api/Contracts";
 import { Repository, LAWYER } from "../api/Repository";
 import { CONTRACT as FACTORY, RepositoryFactory } from "../api/RepositoryFactory"; 
+import { createContract } from "../index";
 
 describe('RepositoryFactory tests', () => {
     it('Repository FACTORY works', () => {
@@ -68,7 +69,7 @@ test('repository_check_WithNoRequirements', () => {
 test('repository_check_WithOneMissingRequirement_Throws', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<number> = Contract.create<number>();
+            const contract: Contract<number> = createContract<number>();
             repository.require(contract);
 
             Tools.assertThrows(ContractException, () => {
@@ -81,7 +82,7 @@ test('repository_check_WithOneMissingRequirement_Throws', () => {
 test('repository_check_WithFulfilledRequirements', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<number> = Contract.create<number>();
+            const contract: Contract<number> = createContract<number>();
             repository.require(contract);
             using useBinding = contracts.bind(contract, () => 42);
 
@@ -93,7 +94,7 @@ test('repository_check_WithFulfilledRequirements', () => {
 test('void repository_store_isBound', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<string> = Contract.create<string>();
+            const contract: Contract<string> = createContract<string>();
             {
                 using useBinding = repository.store(contract, () => "x");
                 Tools.assertTrue(contracts.isBound(contract), "Contract should have been bound");
@@ -106,7 +107,7 @@ test('void repository_store_isBound', () => {
 test('repository_store_Works', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<string> = Contract.create<string>();
+            const contract: Contract<string> = createContract<string>();
             {
                 using useBinding = repository.store(contract, () => "x");
                 const text: string = contracts.enforce(contract);
@@ -119,7 +120,7 @@ test('repository_store_Works', () => {
 test('repository_store_WhenClosedTwice_DoesNothing', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<number> = Contract.create<number>();
+            const contract: Contract<number> = createContract<number>();
             using useBinding = repository.store(contract, () => 7);
             Tools.assertIdempotent(useBinding)
         }
@@ -129,7 +130,7 @@ test('repository_store_WhenClosedTwice_DoesNothing', () => {
 test('repository_store_WhenClosedTwice_DoesNothing', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<string> = Contract.create<string>();
+            const contract: Contract<string> = createContract<string>();
             using closeStore = repository.store(contract, () => "x");
             Tools.assertIdempotent(closeStore);
         }
@@ -139,7 +140,7 @@ test('repository_store_WhenClosedTwice_DoesNothing', () => {
 test('repository_open_WhenCalledTwice_DoesNothing', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<string> = Contract.create<string>();
+            const contract: Contract<string> = createContract<string>();
             using useBinding = repository.store(contract, () => "y");
             using usingSecondOpen = repository.open();
             Tools.assertEquals("y", contracts.enforce(contract), "contract deliverable should not change");
@@ -150,7 +151,7 @@ test('repository_open_WhenCalledTwice_DoesNothing', () => {
 test('repository_close_WhenCalledTwice_DoesNothing', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<number> = Contract.create<number>();
+            const contract: Contract<number> = createContract<number>();
 
             using usingSecond = repository.open();
             Tools.assertIdempotent(usingSecond);
@@ -199,7 +200,7 @@ test('void repository_close_ReleasesResources', () => {
 test('repository_keep_ReplaceWhenOpen_Throws', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<string> = Contract.create<string>();
+            const contract: Contract<string> = createContract<string>();
             repository.keep(contract, () => "x");
 
             using closeRepository = repository.open();
@@ -209,7 +210,7 @@ test('repository_keep_ReplaceWhenOpen_Throws', () => {
 });
 
 test('repository_keep_ReplaceBeforeOpen_Works', () => {
-    const contract: Contract<string> = Contract.create<string>();
+    const contract: Contract<string> = createContract<string>();
 
     runWithScenario({
         beforeRepositoryOpen: function (repository: Repository): void {
@@ -225,7 +226,7 @@ test('repository_keep_ReplaceBeforeOpen_Works', () => {
 test('repository_keep_Replace_Works', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<string> = Contract.create<string>({ isReplaceable: true });
+            const contract: Contract<string> = createContract<string>({ isReplaceable: true });
             using closeFirstBinding = contracts.bind(contract, () => "x");
             repository.keep(contract, () => "y");
             const text: string = contracts.enforce(contract);
@@ -237,7 +238,7 @@ test('repository_keep_Replace_Works', () => {
 test('repository_keep_WhenNotReplaceableAndBound_IsIgnored', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<string> = Contract.create<string>();
+            const contract: Contract<string> = createContract<string>();
             using closeFirstBinding = contracts.bind(contract, () => "x");
             repository.keep(contract, () => "y");
             const text: string = contracts.enforce(contract);
@@ -249,7 +250,7 @@ test('repository_keep_WhenNotReplaceableAndBound_IsIgnored', () => {
 test('repository_keep_WhenNotReplaceableAndBoundAnd_BIND_ALWAYS_Throws', () => {
     runWithScenario({
         accept: function (contracts: Contracts, repository: Repository): void {
-            const contract: Contract<string> = Contract.create<string>({
+            const contract: Contract<string> = createContract<string>({
                 isReplaceable: false
             });
 

--- a/src/test/SingletonPromisor.test.ts
+++ b/src/test/SingletonPromisor.test.ts
@@ -6,7 +6,7 @@ import { Contracts } from "../api/Contracts";
 import { Contract } from "../api/Contract";
 import { inlinePromisor, Promisor } from "../api/Promisor";
 import { PromisorFactory as PromisorFactory, CONTRACT as PROMISORS_CONTRACT } from "../api/PromisorFactory";
-
+import { createContract } from "../index";
 
 generateSingletonSuite<Date>({
     name: 'Singleton Promisor with current Date',
@@ -61,7 +61,7 @@ export function generateSingletonSuite<T>(options: TestSuiteOptions<T>) {
             it(`case ${index}: when value is ${testCase?.help ?? testCase.value}`, () => {
                 Tools.withContracts((contracts: Contracts) => {
                     const promisorFactory: PromisorFactory = contracts.enforce(PROMISORS_CONTRACT);
-                    const contract: Contract<T> = Contract.create<T>();
+                    const contract: Contract<T> = createContract<T>();
                     const valuePromisor: Promisor<T> = inlinePromisor<T>(testCase.value);
                     const promisor: Promisor<T> = promisorFactory.createSingleton<T>(valuePromisor)
 

--- a/src/test/Test.tools.test.ts
+++ b/src/test/Test.tools.test.ts
@@ -8,7 +8,7 @@ import { Contracts, Config as ContractsConfig } from "../api/Contracts";
 import { Contract, Config as ContractConfig } from "../api/Contract";
 import { AutoClose } from "../api/AutoClose";
 import { ClassCastException } from "../api/ClassCastException";
-import { createContracts } from "../index"
+import { createContract, createContracts } from "../index"
 
 describe('test utilities', () => {
     it('Dummy test', () => {
@@ -448,7 +448,7 @@ export class Tools {
     }
 
     public static createStringContract(): Contract<string> {
-        return Contract.create<string>({
+        return createContract<string>({
             cast(instance: unknown): string {
                 return instance as string;
             },

--- a/src/test/ValuePromisor.test.ts
+++ b/src/test/ValuePromisor.test.ts
@@ -6,6 +6,7 @@ import { Contracts } from "../api/Contracts";
 import { Contract } from "../api/Contract";
 import { Promisor } from "../api/Promisor";
 import { PromisorFactory, CONTRACT as PROMISOR_FACTORY_CONTRACT } from "../api/PromisorFactory";
+import { createContract } from "../index";
 
 generateValueSuite<string>({
     name: 'Value Promisor with primitive string values',
@@ -82,7 +83,7 @@ function generateValueSuite<T>(options: TestSuiteOptions<T>) {
             it(`case ${index}: when value is ${testCase?.help ?? testCase.value}`, () => {
                 Tools.withContracts((contracts: Contracts) => {
                     const promisorFactory: PromisorFactory = contracts.enforce(PROMISOR_FACTORY_CONTRACT);
-                    const contract: Contract<T> = Contract.create<T>();
+                    const contract: Contract<T> = createContract<T>();
                     const promisor: Promisor<T> = promisorFactory.createValue<T>(testCase.value)
 
                     using usingPromisor = contracts.bind(contract, promisor);


### PR DESCRIPTION
## Pull request overview

This PR refactors the Contract implementation by splitting the concrete `Contract` class into an interface and a new `RatifiedContract` implementation class. The main goal is to separate the contract abstraction from its concrete implementation, improving code modularity and following interface segregation principles.

### Key Changes
- Converted `Contract` from a class to an interface with method signatures only
- Created new `RatifiedContract` class that implements the `Contract` interface with all the original logic
- Updated `createContract()` function to delegate to `RatifiedContract.create()` instead of `Contract.create()`

### Reviewed changes

Copilot reviewed 23 out of 23 changed files in this pull request and generated 6 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/api/Contract.ts | Converted from concrete class to interface, removing all implementation details |
| src/api/RatifiedContract.ts | New implementation file containing the concrete `RatifiedContract` class with all original Contract logic |
| src/index.ts | Updated `createContract` export to use `RatifiedContract.create()` |
| src/api/Validate.ts | Updated to import and use `createContract` from RatifiedContract |
| src/api/Promisor.ts | Updated Lawyer to use `createContract` from RatifiedContract |
| src/api/PromisorFactory.ts | Updated Lawyer to use `createContract` from RatifiedContract |
| src/api/Repository.ts | Updated Lawyer to use `createContract` from RatifiedContract |
| src/api/RepositoryFactory.ts | Updated Lawyer to use `createContract` from RatifiedContract |
| src/api/AtomicBoolean.ts | Updated Lawyer to use `createContract` from RatifiedContract |
| src/api/AtomicBooleanFactory.ts | Updated Lawyer to use `createContract` from RatifiedContract |
| src/api/AtomicInteger.ts | Updated Lawyer to use `createContract` from RatifiedContract |
| src/api/AtomicIntegerFactory.ts | Updated Lawyer to use `createContract` from RatifiedContract |
| src/api/AtomicReference.ts | Updated Lawyer to use `createContract` from RatifiedContract |
| src/api/AtomicReferenceFactory.ts | Updated Lawyer to use `createContract` from RatifiedContract |
| src/test/Contract.test.ts | Replaced `Contract.create()` calls with `createContract()` and removed duck-typing security test |
| src/test/Contract.tools.test.ts | Replaced `Contract.create()` with `createContract()`, improved type safety (any → unknown) |
| src/test/Test.tools.test.ts | Added `createContract` import and replaced `Contract.create()` call |
| src/test/ValuePromisor.test.ts | Added `createContract` import and replaced `Contract.create()` call |
| src/test/SingletonPromisor.test.ts | Added `createContract` import and replaced `Contract.create()` call |
| src/test/Repository.test.ts | Added `createContract` import and replaced all `Contract.create()` calls |
| src/test/LifeCyclePromisor.test.ts | Added `createContract` import and replaced `Contract.create()` call |
| src/test/Lawyer.tools.test.ts | Added `createContract` import and replaced `Contract.create()` call |
| src/test/ExtractorPromisor.test.ts | Added `createContract` import and replaced `Contract.create()` call |
</details>


