### PR TITLE
rename generic unwrap to specific name

### DIFF
--- a/src/api/AutoClose.ts
+++ b/src/api/AutoClose.ts
@@ -95,7 +95,7 @@ export interface AutoCloseWrapper extends AutoClose {
  */
 function guardAutoCloseWrapper(instance: unknown): instance is RequiredType<AutoCloseWrapper> {
   return guardFunctions(instance, 'unwrapAutoCloseType');
-} 
+}
 
 /**
  * Convert a simple runnable into an AutoClose with dispose


### PR DESCRIPTION
# rename generic unwrap to specific name

## Description

rename generic unwrap to specific name

## Pull request overview

This pull request renames the generic `unwrap()` method to the more specific `unwrapAutoCloseType()` in the `AutoCloseWrapper` interface, improving code clarity and consistency with similar patterns in the codebase (e.g., `unwrapPromisorType()` in Promisor.ts).

**Changes:**
- Renamed `unwrap()` method to `unwrapAutoCloseType()` in the `AutoCloseWrapper` interface
- Introduced a new `guardAutoCloseWrapper()` guard function for type checking
- Updated all internal usages of the method in `inlineAutoClose()` and `unwrapAutoClose()` functions

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement or restructuring without changing external behavior)
- [ ] Documentation update
- [ ] Chore (e.g., dependency updates, build tooling changes)

## Checklist:

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if necessary).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Additional Notes
