### PR TITLE
Convenience allowing undefined initial value

### DIFF
--- a/src/auxiliary/Convenience.ts
+++ b/src/auxiliary/Convenience.ts
@@ -31,7 +31,7 @@ export { AtomicInteger } from "@jonloucks/contracts-ts/auxiliary/AtomicInteger";
  * @param initialValue the initial boolean value
  * @returns the AtomicBoolean instance
  */
-export function createAtomicBoolean(initialValue: boolean): RequiredType<AtomicBoolean> {
+export function createAtomicBoolean(initialValue?: boolean): RequiredType<AtomicBoolean> {
   return CONTRACTS.enforce(BOOLEAN_FACTORY).createAtomicBoolean(initialValue);
 }
 
@@ -41,7 +41,7 @@ export function createAtomicBoolean(initialValue: boolean): RequiredType<AtomicB
  * @param initialValue the initial reference value
  * @returns the AtomicReference instance
  */
-export function createAtomicReference<T>(initialValue: T): RequiredType<AtomicReference<T>> {
+export function createAtomicReference<T>(initialValue?: T): RequiredType<AtomicReference<T>> {
   return CONTRACTS.enforce(REFERENCE_FACTORY).createAtomicReference(initialValue);
 }
 
@@ -51,6 +51,6 @@ export function createAtomicReference<T>(initialValue: T): RequiredType<AtomicRe
  * @param initialValue the initial integer value
  * @returns the AtomicInteger instance
  */
-export function createAtomicInteger(initialValue: number): RequiredType<AtomicInteger> {
+export function createAtomicInteger(initialValue?: number): RequiredType<AtomicInteger> {
   return CONTRACTS.enforce(INTEGER_FACTORY).createAtomicInteger(initialValue);
 }


### PR DESCRIPTION
# Convenience allowing undefined initial value

## Description

Convenience allowing undefined initial value

## Pull request overview

This PR updates the auxiliary convenience helpers so that callers can omit the initial value when creating atomic types, aligning their TypeScript signatures with the underlying factory interfaces and existing runtime behavior.

**Changes:**
- Relaxed `createAtomicBoolean` to accept an optional `initialValue?: boolean`.
- Relaxed `createAtomicReference` to accept an optional `initialValue?: T`.
- Relaxed `createAtomicInteger` to accept an optional `initialValue?: number`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (code improvement or restructuring without changing external behavior)
- [ ] Documentation update
- [ ] Chore (e.g., dependency updates, build tooling changes)

## Checklist:

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if necessary).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Additional Notes
